### PR TITLE
Compress bit arrays

### DIFF
--- a/ArduNet/ArduNet.ino
+++ b/ArduNet/ArduNet.ino
@@ -9,6 +9,7 @@
 
 #include "neuralROM.h"            //import libraries
 #include "sprites.h"
+#include "bit_array.h"
 #include <Arduboy2.h>
 #include <stdlib.h>
 
@@ -40,8 +41,8 @@ uint8_t counter = 0;
 
 uint16_t preSynapticNeuronList[maxSynapse];  //interface array to hold all the different presynaptic neurons
 //int8_t learningArray[302];          //an array that, for each neuron, holds its firing history
-bool outputList[302];     //list of neurons
-bool nextOutputList[302]; //buffer to solve conflicting time differentials in firing
+BitArray<302> outputList;     //list of neurons
+BitArray<302> nextOutputList; //buffer to solve conflicting time differentials in firing
 
 struct Neuron {
   int16_t cellID;

--- a/ArduNet/bit_array.h
+++ b/ArduNet/bit_array.h
@@ -17,11 +17,13 @@ class BitArray {
     struct bit_proxy {
         uint8_t* byte;
         uint8_t bit;
-        void operator=(bool val) {
+        bit_proxy& operator=(bool val) {
             *byte = (*byte & ~(1 << bit)) | (val << bit); // change bit in referenced byte when setting
+            return *this;
         }
-        void operator=(bit_proxy proxy) {
-            *this = static_cast<int>(proxy); // setting to element of another array, cast to int type
+        bit_proxy& operator=(bit_proxy& other) {
+            *this = static_cast<int>(other); // setting to element of another array, cast to int type
+            return *this;
         }
         operator int() {
             return (*byte & (1 << bit)) >> bit; // get the bit on its own for standard use

--- a/ArduNet/bit_array.h
+++ b/ArduNet/bit_array.h
@@ -27,13 +27,22 @@ class BitArray {
      * operator to return an object with logic to mutate the element of the
      * enclosing BitArray when assigned.
      */
-    struct BitProxy {
+    class BitProxy {
 
         uint8_t* byte;
-        uint8_t bit;
+        uint8_t bit_idx;
+
+        public:
+        BitProxy(uint8_t* byte, uint8_t bit_idx) : byte(byte), bit_idx(bit_idx) {}
+        BitProxy(BitProxy&);
+
+        // Implicit conversion to mimic bool
+        operator bool() {
+            return (*byte & (1 << bit_idx)) >> bit_idx;
+        }
 
         BitProxy& operator=(bool val) {
-            *byte = (*byte & ~(1 << bit)) | (val << bit);
+            *byte = (*byte & ~(1 << bit_idx)) | (val << bit_idx);
             return *this;
         }
 
@@ -43,10 +52,6 @@ class BitArray {
             return *this;
         }
 
-        // Implicit conversion to mimic bool
-        operator bool() {
-            return (*byte & (1 << bit)) >> bit;
-        }
     };
 
     public:

--- a/ArduNet/bit_array.h
+++ b/ArduNet/bit_array.h
@@ -27,18 +27,18 @@ class BitArray {
      * operator to return an object with logic to mutate the element of the
      * enclosing BitArray when assigned.
      */
-    struct bit_proxy {
+    struct BitProxy {
 
         uint8_t* byte;
         uint8_t bit;
 
-        bit_proxy& operator=(bool val) {
+        BitProxy& operator=(bool val) {
             *byte = (*byte & ~(1 << bit)) | (val << bit);
             return *this;
         }
 
-        // When assigned another bit_proxy, only assign the value of the bit
-        bit_proxy& operator=(bit_proxy& other) {
+        // When assigned another BitProxy, only assign the value of the bit
+        BitProxy& operator=(BitProxy& other) {
             *this = static_cast<int>(other);
             return *this;
         }
@@ -59,8 +59,8 @@ class BitArray {
      * @param idx the index of the element to get
      * @return a proxy for the element
      */
-    bit_proxy operator[](uint16_t idx) {
-        bit_proxy b = { arr + (idx / 8), static_cast<uint8_t>(idx % 8) };
+    BitProxy operator[](uint16_t idx) {
+        BitProxy b = { arr + (idx / 8), static_cast<uint8_t>(idx % 8) };
         return b;
     }
 

--- a/ArduNet/bit_array.h
+++ b/ArduNet/bit_array.h
@@ -1,0 +1,37 @@
+#ifndef BIT_ARRAY_H
+#define BIT_ARRAY_H
+
+#include <stdint.h>
+
+template <uint16_t Length>
+class BitArray {
+
+    public:
+    static const uint16_t length = Length;
+
+    private:
+    static constexpr uint8_t size = (length + 7) / 8 ; // size in bytes
+    uint8_t arr[size] = {0};
+
+    // holds reference to byte in array and specific bit so bits can be set with subscript operator
+    struct bit_proxy {
+        uint8_t* byte;
+        uint8_t bit;
+        void operator=(bool val) {
+            *byte = (*byte & ~(1 << bit)) | (val << bit); // change bit in referenced byte when setting
+        }
+        operator int() {
+            return (*byte & (1 << bit)) >> bit; // get the bit on its own for standard use
+        }
+    };
+
+    public:
+    // when subscripting, quietly return a proxy that references the byte and remembers the relevant bit
+    bit_proxy operator[](uint16_t idx) {
+        bit_proxy b = { arr + (idx / 8), static_cast<uint8_t>(idx % 8) };
+        return b;
+    }
+
+};
+
+#endif

--- a/ArduNet/bit_array.h
+++ b/ArduNet/bit_array.h
@@ -11,7 +11,7 @@ class BitArray {
 
     private:
     static constexpr uint8_t size = (length + 7) / 8 ; // size in bytes
-    uint8_t arr[size] = {0};
+    uint8_t arr[size] = { 0 };
 
     // holds reference to byte in array and specific bit so bits can be set with subscript operator
     struct bit_proxy {
@@ -19,6 +19,9 @@ class BitArray {
         uint8_t bit;
         void operator=(bool val) {
             *byte = (*byte & ~(1 << bit)) | (val << bit); // change bit in referenced byte when setting
+        }
+        void operator=(bit_proxy proxy) {
+            *this = static_cast<int>(proxy); // setting to element of another array, cast to int type
         }
         operator int() {
             return (*byte & (1 << bit)) >> bit; // get the bit on its own for standard use


### PR DESCRIPTION
Added a `BitArray` type to operate on an array of `bool` in minimal space. Change `outputList` and `nextOutputList` from type `bool[]` to `BitArray`.