### PR TITLE
Fix mismatch between compressed array and reader

### DIFF
--- a/ArduNet_Matrix/ArduNet_Matrix.ino
+++ b/ArduNet_Matrix/ArduNet_Matrix.ino
@@ -58,7 +58,7 @@ float dbRatio = 0;
 uint8_t counter = 0;
 
 
-SizedIntArrayReader<9> NEURAL_ROM(COMPRESSED_NEURAL_ROM, 7578, -70);
+SizedIntArrayReader<9> NEURAL_ROM(COMPRESSED_NEURAL_ROM, 7578, -70, true);
 
 uint16_t preSynapticNeuronList[maxSynapse];  //interface array to hold all the different presynaptic neurons
 //BitArray<302> <maxSynapse> learningArray;    //an array that, for each neuron, holds its firing history

--- a/Ardunet_Sim/ArduNet_Sim.ino
+++ b/Ardunet_Sim/ArduNet_Sim.ino
@@ -102,7 +102,7 @@ bool sated = false;       //if the worm is not hungry
 //uint16_t foodTouchCounter = 0;  //how long the food has been eaten for
 
 //massive thanks to Dinokaiz2 for help with the bit array functionality!!!
-SizedIntArrayReader<9> NEURAL_ROM(COMPRESSED_NEURAL_ROM, 7578, -70);
+SizedIntArrayReader<9> NEURAL_ROM(COMPRESSED_NEURAL_ROM, 7578, -70, true);
 
 //BitArray<> learningArray;  //an array that, for each neuron that does hebbian learning, holds a form of simplified output history
 BitArray<302> outputList;     //list of neurons


### PR DESCRIPTION
SizedIntArrayReader expected a different structure than the generator program was building. The generator placed integers in order, starting with the most significant byte. The reader previously expected the byte containing the least significant bit to lead. Now it reads the generated structure. Needs run time optimization.